### PR TITLE
replaces SASS with Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Caffeine
 
-Caffeine is a set of SASS mixins and functions ready to use for projects. First versions of Caffeine were embedded as \_system definitions in [Melange](http://melange.io). As the mixins and functions grow, they are seperated from Melange in order to use them freely.
+Caffeine is a set of Sass mixins and functions ready to use for projects. First versions of Caffeine were embedded as \_system definitions in [Melange](http://melange.io). As the mixins and functions grow, they are seperated from Melange in order to use them freely.
 
 ## Installation
 Caffeine can directly install your project by copying the contents of lib folder to your assets, and [npm](https://www.npmjs.org/) or [bower](http://bower.io) packages. Just run,
@@ -16,7 +16,7 @@ or with bower
 bower install caffeine
 ```
 
-After copying the files, at the top of your SASS file add the following line
+After copying the files, at the top of your Sass file add the following line
 ```SCSS
 @import "<path-to-caffeine>/caffeine";
 ```

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Bilal Cinarli <bcinarli@gmail.com>"
   ],
-  "description": "Caffeine is a set of SASS mixins and functions ready use for projects.",
+  "description": "Caffeine is a set of Sass mixins and functions ready use for projects.",
   "main": "lib/_caffeine.scss",
   "keywords": [
     "sass",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kafein",
   "version": "0.4.0",
-  "description": "Caffeine is a set of SASS mixins and functions ready use for projects.",
+  "description": "Caffeine is a set of Sass mixins and functions ready use for projects.",
   "repository": {
 	  "type": "git",
 	  "url": "https://github.com/bcinarli/caffeine.git"


### PR DESCRIPTION
As Sass is a 'backronym' it's not capilisied :) 

(I'll be adding this to Sass News next week too)
