### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Caffeine
+# Caffeine
 
 Caffeine is a set of Sass mixins and functions ready to use for projects. First versions of Caffeine were embedded as \_system definitions in [Melange](http://melange.io). As the mixins and functions grow, they are seperated from Melange in order to use them freely.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
